### PR TITLE
Set default dropdown value to first template type

### DIFF
--- a/assets/javascripts/discourse/controllers/template-manager.js.es6
+++ b/assets/javascripts/discourse/controllers/template-manager.js.es6
@@ -26,7 +26,7 @@ export default Ember.Controller.extend(ModalFunctionality, {
   },
 
   onShow: function() {
-    this.setProperties({templateName: "", templateType: "regular"});
+    this.setProperties({templateName: "", templateType: this.templateTypes[0].value});
   },
 
   init: function () {


### PR DESCRIPTION
Dropdown defaulted to 'regular' if it was present, earlier. Fixed this issue.